### PR TITLE
Fix monaco vertical resize

### DIFF
--- a/packages/ui/src/views/AppCenter/Request.vue
+++ b/packages/ui/src/views/AppCenter/Request.vue
@@ -77,6 +77,7 @@ export default {
 }
 .content-wrapper {
   position: relative;
+  overflow: hidden;
   @include flex($column: true, $flex: 1);
 }
 .content-overlay {

--- a/packages/ui/src/views/AppCenter/Response.vue
+++ b/packages/ui/src/views/AppCenter/Response.vue
@@ -76,6 +76,7 @@ export default {
 }
 .content-wrapper {
   position: relative;
+  overflow: hidden;
   @include flex($column: true, $flex: 1);
 }
 .content-overlay {

--- a/packages/ui/src/views/AppCenter/index.vue
+++ b/packages/ui/src/views/AppCenter/index.vue
@@ -176,6 +176,7 @@ export default {
   @include flex($row: true, $flex: 1, $ml: 2);
 }
 .center-editors {
+  overflow: hidden;
   @include flex($row: true, $flex: 1, $ph: 2, $pv: 1);
 }
 .center-editors-resize {

--- a/packages/ui/src/views/index.vue
+++ b/packages/ui/src/views/index.vue
@@ -46,6 +46,7 @@ export default {
 
       return {
         height: `${100 - heightLogs}%`,
+        overflow: 'hidden',
       }
     },
     styleFooter() {


### PR DESCRIPTION
When you hide/show the bottom logs window, Monaco resizing breaks at times and it doesn't resize. This PR fixes that (Tested on Chrome/Safari)